### PR TITLE
fix: use typed FileContent result so base64 decoding works correctly

### DIFF
--- a/operations/repository/get_file_content.go
+++ b/operations/repository/get_file_content.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"gitee.com/oschina/mcp-gitee/operations/types"
 	"gitee.com/oschina/mcp-gitee/utils"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -49,6 +50,6 @@ func GetFileContentHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 	}
 	apiUrl := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, url.QueryEscape(path))
 	giteeClient := utils.NewGiteeClient("GET", apiUrl, utils.WithContext(ctx), utils.WithQuery(map[string]interface{}{"ref": ref}))
-	var fileContents interface{}
+	var fileContents types.FileContent
 	return giteeClient.HandleMCPResult(&fileContents)
 }

--- a/operations/repository/get_file_content.go
+++ b/operations/repository/get_file_content.go
@@ -1,9 +1,12 @@
 package repository
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"gitee.com/oschina/mcp-gitee/operations/types"
 	"gitee.com/oschina/mcp-gitee/utils"
@@ -48,8 +51,49 @@ func GetFileContentHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 	if !ok {
 		ref = ""
 	}
-	apiUrl := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, url.QueryEscape(path))
+
+	// Encode each path segment individually to avoid encoding / to %2F
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		parts[i] = url.PathEscape(part)
+	}
+	escapedPath := strings.Join(parts, "/")
+
+	apiUrl := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	giteeClient := utils.NewGiteeClient("GET", apiUrl, utils.WithContext(ctx), utils.WithQuery(map[string]interface{}{"ref": ref}))
-	var fileContents types.FileContent
-	return giteeClient.HandleMCPResult(&fileContents)
+
+	// Do the HTTP request
+	_, err := giteeClient.Do()
+	if err != nil {
+		switch {
+		case utils.IsAuthError(err):
+			return mcp.NewToolResultError("Authentication failed: Please check your Gitee access token"), err
+		case utils.IsNetworkError(err):
+			return mcp.NewToolResultError("Network error: Unable to connect to Gitee API"), err
+		case utils.IsAPIError(err):
+			giteeErr := err.(*utils.GiteeError)
+			return mcp.NewToolResultError(fmt.Sprintf("API error (%d): %s", giteeErr.Code, giteeErr.Details)), err
+		default:
+			return mcp.NewToolResultError(err.Error()), err
+		}
+	}
+
+	body, err := giteeClient.GetRespBody()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to read response body: %s", err.Error())),
+			utils.NewInternalError(errors.New(err.Error()))
+	}
+
+	// Detect whether the response is a JSON array (directory listing) or object (single file)
+	trimmed := bytes.TrimLeft(body, " \t\r\n")
+
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		// Response is an array (directory listing)
+		var fileContents []types.FileContent
+		return giteeClient.ProcessResponse(body, &fileContents)
+	} else {
+		// Response is an object (single file)
+		var fileContent types.FileContent
+		return giteeClient.ProcessResponse(body, &fileContent)
+	}
 }

--- a/operations/repository/get_file_content.go
+++ b/operations/repository/get_file_content.go
@@ -1,14 +1,11 @@
 package repository
 
 import (
-	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 
-	"gitee.com/oschina/mcp-gitee/operations/types"
 	"gitee.com/oschina/mcp-gitee/utils"
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -62,38 +59,6 @@ func GetFileContentHandler(ctx context.Context, request mcp.CallToolRequest) (*m
 	apiUrl := fmt.Sprintf("/repos/%s/%s/contents/%s", owner, repo, escapedPath)
 	giteeClient := utils.NewGiteeClient("GET", apiUrl, utils.WithContext(ctx), utils.WithQuery(map[string]interface{}{"ref": ref}))
 
-	// Do the HTTP request
-	_, err := giteeClient.Do()
-	if err != nil {
-		switch {
-		case utils.IsAuthError(err):
-			return mcp.NewToolResultError("Authentication failed: Please check your Gitee access token"), err
-		case utils.IsNetworkError(err):
-			return mcp.NewToolResultError("Network error: Unable to connect to Gitee API"), err
-		case utils.IsAPIError(err):
-			giteeErr := err.(*utils.GiteeError)
-			return mcp.NewToolResultError(fmt.Sprintf("API error (%d): %s", giteeErr.Code, giteeErr.Details)), err
-		default:
-			return mcp.NewToolResultError(err.Error()), err
-		}
-	}
-
-	body, err := giteeClient.GetRespBody()
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to read response body: %s", err.Error())),
-			utils.NewInternalError(errors.New(err.Error()))
-	}
-
-	// Detect whether the response is a JSON array (directory listing) or object (single file)
-	trimmed := bytes.TrimLeft(body, " \t\r\n")
-
-	if len(trimmed) > 0 && trimmed[0] == '[' {
-		// Response is an array (directory listing)
-		var fileContents []types.FileContent
-		return giteeClient.ProcessResponse(body, &fileContents)
-	} else {
-		// Response is an object (single file)
-		var fileContent types.FileContent
-		return giteeClient.ProcessResponse(body, &fileContent)
-	}
+	// Use the specialized handler for polymorphic file content responses
+	return giteeClient.HandleMCPResultForFileContent()
 }

--- a/utils/gitee_client.go
+++ b/utils/gitee_client.go
@@ -287,6 +287,57 @@ func (g *GiteeClient) ProcessResponse(body []byte, object any) (*mcp.CallToolRes
 	return mcp.NewToolResultText(string(result)), nil
 }
 
+// HandleMCPResultForFileContent handles polymorphic API responses for file content
+// The API returns either a single FileContent object or a []FileContent array
+func (g *GiteeClient) HandleMCPResultForFileContent() (*mcp.CallToolResult, error) {
+	// Do the HTTP request and handle errors
+	_, err := g.Do()
+	if err != nil {
+		switch {
+		case IsAuthError(err):
+			return mcp.NewToolResultError("Authentication failed: Please check your Gitee access token"), err
+		case IsNetworkError(err):
+			return mcp.NewToolResultError("Network error: Unable to connect to Gitee API"), err
+		case IsAPIError(err):
+			giteeErr := err.(*GiteeError)
+			return mcp.NewToolResultError(fmt.Sprintf("API error (%d): %s", giteeErr.Code, giteeErr.Details)), err
+		default:
+			return mcp.NewToolResultError(err.Error()), err
+		}
+	}
+
+	body, err := g.GetRespBody()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to read response body: %s", err.Error())),
+			NewInternalError(errors.New(err.Error()))
+	}
+
+	// Use json.RawMessage to detect response type without unmarshaling into concrete type
+	var raw json.RawMessage
+	if err := json.Unmarshal(body, &raw); err != nil {
+		errorMessage := fmt.Sprintf("Failed to parse response: %v", err)
+		return mcp.NewToolResultError(errorMessage), NewInternalError(errors.New(errorMessage))
+	}
+
+	// Detect whether the response is a JSON array (directory listing) or object (single file)
+	if len(raw) == 0 {
+		// Empty response - treat as empty array
+		var fileContents []types.FileContent
+		return g.ProcessResponse(body, &fileContents)
+	}
+
+	if raw[0] == '[' {
+		// Response is an array (directory listing)
+		var fileContents []types.FileContent
+		return g.ProcessResponse(body, &fileContents)
+	} else {
+		// Response is an object (single file) or other JSON type
+		// The API should only return object for single files, but we handle other cases gracefully
+		var fileContent types.FileContent
+		return g.ProcessResponse(body, &fileContent)
+	}
+}
+
 func WithContext(ctx context.Context) Option {
 	return func(client *GiteeClient) {
 		if ctx != nil {

--- a/utils/gitee_client.go
+++ b/utils/gitee_client.go
@@ -244,7 +244,15 @@ func (g *GiteeClient) HandleMCPResult(object any) (*mcp.CallToolResult, error) {
 			NewInternalError(errors.New(err.Error()))
 	}
 
-	if err = json.Unmarshal(body, object); err != nil {
+	return g.ProcessResponse(body, object)
+}
+
+func (g *GiteeClient) ProcessResponse(body []byte, object any) (*mcp.CallToolResult, error) {
+	if object == nil {
+		return mcp.NewToolResultText("Operation completed successfully"), nil
+	}
+
+	if err := json.Unmarshal(body, object); err != nil {
 		errorMessage := fmt.Sprintf("Failed to parse response: %v", err)
 		return mcp.NewToolResultError(errorMessage), NewInternalError(errors.New(errorMessage))
 	}


### PR DESCRIPTION
The handler was using interface{} as the result type, which caused HandleMCPResult's type switch to never match *types.FileContent. The base64-encoded content was returned as-is instead of being decoded.