### PR TITLE
fix: prevent panic when LLM passes numeric types for number parameter (string type)

### DIFF
--- a/operations/comments/create_comment.go
+++ b/operations/comments/create_comment.go
@@ -54,7 +54,10 @@ func CreateCommentHandleFunc(ctx context.Context, request mcp.CallToolRequest) (
 
 	owner := args["owner"].(string)
 	repo := args["repo"].(string)
-	number := args["number"].(string)
+	number, err := utils.SafelyGetString("number", args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), err
+	}
 
 	var apiUrl string
 	switch resourceType {

--- a/operations/comments/list_comments.go
+++ b/operations/comments/list_comments.go
@@ -69,7 +69,10 @@ func ListCommentsHandleFunc(ctx context.Context, request mcp.CallToolRequest) (*
 
 	owner := args["owner"].(string)
 	repo := args["repo"].(string)
-	number := args["number"].(string)
+	number, err := utils.SafelyGetString("number", args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), err
+	}
 
 	var apiUrl string
 	switch resourceType {

--- a/operations/issues/comment_issue.go
+++ b/operations/issues/comment_issue.go
@@ -46,7 +46,10 @@ func CommentIssueHandleFunc(ctx context.Context, request mcp.CallToolRequest) (*
 	args, _ := utils.ConvertArgumentsToMap(request.Params.Arguments)
 	owner := args["owner"].(string)
 	repo := args["repo"].(string)
-	number := args["number"].(string)
+	number, err := utils.SafelyGetString("number", args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), err
+	}
 
 	// Construct the API URL for creating a comment on an issue
 	apiUrl := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", owner, repo, number)

--- a/operations/issues/get_issue_detail.go
+++ b/operations/issues/get_issue_detail.go
@@ -88,10 +88,9 @@ func GetIssueDetailHandleFunc(getType string) server.ToolHandlerFunc {
 		if len(config.PathParams) > 0 {
 			apiUrlArgs := make([]interface{}, len(config.PathParams))
 			for idx, param := range config.PathParams {
-				value, ok := args[param].(string)
-				if !ok {
-					errMsg := fmt.Sprintf("missing required path parameter: %s", param)
-					return mcp.NewToolResultError(errMsg), fmt.Errorf(errMsg)
+				value, err := utils.SafelyGetString(param, args)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), err
 				}
 				apiUrlArgs[idx] = value
 			}

--- a/operations/issues/list_issue_comments.go
+++ b/operations/issues/list_issue_comments.go
@@ -61,7 +61,10 @@ func ListIssueCommentsHandleFunc(ctx context.Context, request mcp.CallToolReques
 	args, _ := utils.ConvertArgumentsToMap(request.Params.Arguments)
 	owner := args["owner"].(string)
 	repo := args["repo"].(string)
-	number := args["number"].(string)
+	number, err := utils.SafelyGetString("number", args)
+	if err != nil {
+		return mcp.NewToolResultError(err.Error()), err
+	}
 
 	// Construct the API URL for listing issue comments
 	apiUrl := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", owner, repo, number)

--- a/operations/issues/update_issue.go
+++ b/operations/issues/update_issue.go
@@ -67,10 +67,9 @@ func UpdateIssueHandleFuncCommon(updateType string) func(ctx context.Context, re
 			args, _ := utils.ConvertArgumentsToMap(request.Params.Arguments)
 			apiUrlArgs := make([]interface{}, 0, len(config.PathParams))
 			for _, param := range config.PathParams {
-				value, ok := args[param].(string)
-				if !ok {
-					errMsg := fmt.Sprintf("Missing required path parameter: %s", param)
-					return mcp.NewToolResultError(errMsg), fmt.Errorf(errMsg)
+				value, err := utils.SafelyGetString(param, args)
+				if err != nil {
+					return mcp.NewToolResultError(err.Error()), err
 				}
 				apiUrlArgs = append(apiUrlArgs, value)
 			}

--- a/utils/convert.go
+++ b/utils/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 )
 
 // SafelyConvertToInt 尝试将各种类型安全地转换为 int
@@ -42,6 +43,32 @@ func SafelyConvertToInt(value interface{}) (int, error) {
 		return 0, NewParamError("number", "must be a valid integer")
 	default:
 		return 0, NewParamError("number", fmt.Sprintf("unsupported type: %v", reflect.TypeOf(value)))
+	}
+}
+
+// SafelyGetString 从 map 中安全提取 string 类型的参数值
+// 支持 string, float64, float32, int, int32, int64 类型
+// 对于数值类型自动转换为字符串表示，避免 JSON 反序列化导致的类型断言 panic
+func SafelyGetString(key string, args map[string]interface{}) (string, error) {
+	value, exists := args[key]
+	if !exists {
+		return "", NewParamError(key, "parameter is required")
+	}
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case float64:
+		return strconv.Itoa(int(v)), nil
+	case float32:
+		return strconv.Itoa(int(v)), nil
+	case int:
+		return strconv.Itoa(v), nil
+	case int32:
+		return strconv.Itoa(int(v)), nil
+	case int64:
+		return strconv.Itoa(int(v)), nil
+	default:
+		return "", NewParamError(key, fmt.Sprintf("unsupported type: %T", value))
 	}
 }
 


### PR DESCRIPTION
## Problem

When an LLM calls tools like `create_comment`, it sometimes passes the `number` parameter as a JSON number (`42`) instead of a JSON string (`"42"`). Go's JSON unmarshaller deserializes JSON numbers as `float64`, so the bare type assertion `args["number"].(string)` panics at runtime.

## Changes

### `utils/convert.go`
- Added `SafelyGetString(key, args)` — handles `string`, `float64`, `float32`, `int`, `int32`, `int64`; returns a typed `param_error` on missing key or unsupported type
